### PR TITLE
add: fix typo

### DIFF
--- a/add
+++ b/add
@@ -32,7 +32,7 @@ for(f in $*){
 	delpath=.git/index9/$del/$rel/$f
 	mkdir -p `{basename -d $addpath}
 	mkdir -p `{basename -d $delpath}
-	if(!test -e $addpath)
+	if(! test -e $addpath)
 		walk -eq $f > $addpath
 	rm -f $delpath
 }


### PR DESCRIPTION
add was failing:
```
cpu% git/add hello.txt
!test: '/bin/!test' file does not exist
```