### PR TITLE
serve.c:showrefs() - avoid freeing unallocated memory on error path.

### DIFF
--- a/git.1.man
+++ b/git.1.man
@@ -383,7 +383,7 @@ instead of
 .I HEAD.
 When passed the
 .I -s
-option, only a the file statuses are
+option, only the file statuses are
 printed.
 
 .PP

--- a/serve.c
+++ b/serve.c
@@ -31,10 +31,9 @@ showrefs(Conn *c)
 	char **names;
 
 	ret = -1;
-	nrefs = 0;
 	if(resolveref(&head, "HEAD") != -1) {
 		if(fmtpkt(c, "%H HEAD", head) == -1)
-			goto error;
+			goto noref;
 	}
 
 	if((nrefs = listrefs(&refs, &names)) == -1)
@@ -53,6 +52,7 @@ error:
 		free(names[i]);
 	free(names);
 	free(refs);
+noref:
 	return ret;
 }
 


### PR DESCRIPTION
Not sure about plan9 but calling free on unallocated memory is a tad dangerous. If `resolveref(...)` fails early skip to the `return` instead of going through the motions of freeing memory that has never been allocated.