### PR TITLE
Add null pointer checks for strdup

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -904,6 +904,8 @@ main(int argc, char **argv)
 		sysfatal("dirstat .git: %r");
 	username = strdup(d->uid);
 	groupname = strdup(d->gid);
+	if(username == nil || groupname == nil)
+		sysfatal("strdup: memory allocation failed");
 	free(d);
 
 	branches = emalloc(sizeof(char*));

--- a/log.c
+++ b/log.c
@@ -30,7 +30,8 @@ filteradd(Pfilt *pf, char *path)
 		p = smprint("%.*s", (int)(e - path), path);
 	else
 		p = strdup(path);
-
+	if(p == nil)
+		sysfatal("Memory allocation failed");
 	while(e != nil && *e == '/')
 		e++;
 	for(i = 0; i < pf->nsub; i++){

--- a/save.c
+++ b/save.c
@@ -459,6 +459,8 @@ main(int argc, char **argv)
 		idx[nidx].mode = strtol(parts[2], nil, 8);
 		idx[nidx].path = strdup(parts[3]);
 		idx[nidx].order = nidx;
+		if(idx[nidx].path == nil)
+			sysfatal("strdup: memory allocation failed");
 		nidx++;
 		free(ln);
 	}

--- a/walk.c
+++ b/walk.c
@@ -330,6 +330,8 @@ reporel(char *s)
 		s = strdup(s);
 	else
 		s = smprint("%s/%s", wdirpath, s);
+	if(s == nil)
+		sysfatal("smprint or memory allocation failed: %r");
 	p = cleanname(s);
 	n = strlen(repopath);
 	if(strncmp(s, repopath, n) != 0)
@@ -462,6 +464,8 @@ main(int argc, char **argv)
 			idx[nidx].mode = strtol(parts[2], nil, 8);
 			idx[nidx].path = strdup(parts[3]);
 			idx[nidx].order = nidx;
+			if(idx[nidx].path == nil)
+				sysfatal("strdup: memory allocation failed");
 			nidx++;
 			free(ln);
 		}


### PR DESCRIPTION
`strdup` may return null pointer on allocation failures.

I added null pointer checks to calls to `strdup` that were not checked.